### PR TITLE
Fixes signin and provider methods

### DIFF
--- a/api/auth/provider.js
+++ b/api/auth/provider.js
@@ -1,33 +1,35 @@
 ({
   generateToken() {
     const { characters, secret, length } = config.sessions;
-    return metarhia.metautil.generateToken(secret, characters, length);
+    return common.generateToken(secret, characters, length);
   },
 
   saveSession(token, data) {
-    db.pg.update('Session', { data: JSON.stringify(data) }, { token });
+    return db('Session').update(token, { data: JSON.stringify(data) });
   },
 
   startSession(token, data, fields = {}) {
     const record = { token, data: JSON.stringify(data), ...fields };
-    db.crud('Session').create(record);
+    return db('Session').create(record);
   },
 
   async restoreSession(token) {
-    const record = await db.pg.row('Session', ['data'], { token });
+    const record = await db('Session').read(token, 'token', ['data']);
     if (record && record.data) return record.data;
     return null;
   },
 
   deleteSession(token) {
-    db.pg.delete('Session', { token });
+    return db('Session').delete(token, 'token');
   },
 
   async registerUser(login, password) {
-    return db.pg.insert('Account', { login, password });
+    return db('Account').create({ login, password });
   },
 
   async getUser(login) {
-    return db.crud('Account').read(login, 'login');
+    return db('Account')
+      .read(login, 'login')
+      .then((u) => u.rows[0]);
   },
 });

--- a/api/auth/provider.js
+++ b/api/auth/provider.js
@@ -10,7 +10,7 @@
 
   startSession(token, data, fields = {}) {
     const record = { token, data: JSON.stringify(data), ...fields };
-    db.pg.insert('Session', record);
+    db.crud('Session').create(record);
   },
 
   async restoreSession(token) {
@@ -28,6 +28,6 @@
   },
 
   async getUser(login) {
-    return db.pg.row('Account', { login });
+    return db.crud('Account').read(login, 'login');
   },
 });

--- a/api/auth/signin.js
+++ b/api/auth/signin.js
@@ -1,18 +1,15 @@
 ({
   access: 'public',
   method: async ({ login, password }) => {
-    const user = await api.auth
-      .provider()
-      .getUser(login)
-      .then((u) => u.rows[0]);
+    const user = await api.auth.provider().getUser(login);
     if (!user) throw new Error('Incorrect login or password');
     const { id: accountId, password: hash } = user;
-    const valid = await metarhia.metautil.validatePassword(password, hash);
+    const valid = await common.validatePassword(password, hash);
     if (!valid) throw new Error('Incorrect login or password');
     console.log(`Logged user: ${login}`);
     const token = api.auth.provider().generateToken();
     const data = { accountId: user.id };
-    context.client.startSession(token, data); // dont exist jet
+    // context.client.startSession(token, data); // TODO: doesn't exist yet
     const { ip } = context.client;
     api.auth.provider().startSession(token, data, { ip, accountId });
     return { status: 'logged', token };

--- a/api/auth/signin.js
+++ b/api/auth/signin.js
@@ -8,12 +8,11 @@
     if (!user) throw new Error('Incorrect login or password');
     const { id: accountId, password: hash } = user;
     const valid = await metarhia.metautil.validatePassword(password, hash);
-    // regenerate all passwords for data.sql(msut comply with new hashing rules)
     if (!valid) throw new Error('Incorrect login or password');
     console.log(`Logged user: ${login}`);
     const token = api.auth.provider().generateToken();
     const data = { accountId: user.id };
-    context.client.startSession(token, data);
+    context.client.startSession(token, data); // dont exist jet
     const { ip } = context.client;
     api.auth.provider().startSession(token, data, { ip, accountId });
     return { status: 'logged', token };

--- a/api/auth/signin.js
+++ b/api/auth/signin.js
@@ -1,17 +1,21 @@
 ({
   access: 'public',
   method: async ({ login, password }) => {
-    const user = await api.auth.provider.getUser(login);
+    const user = await api.auth
+      .provider()
+      .getUser(login)
+      .then((u) => u.rows[0]);
     if (!user) throw new Error('Incorrect login or password');
-    const { accountId, password: hash } = user;
+    const { id: accountId, password: hash } = user;
     const valid = await metarhia.metautil.validatePassword(password, hash);
+    // regenerate all passwords for data.sql(msut comply with new hashing rules)
     if (!valid) throw new Error('Incorrect login or password');
     console.log(`Logged user: ${login}`);
-    const token = api.auth.provider.generateToken();
-    const data = { accountId: user.accountId };
+    const token = api.auth.provider().generateToken();
+    const data = { accountId: user.id };
     context.client.startSession(token, data);
     const { ip } = context.client;
-    api.auth.provider.startSession(token, data, { ip, accountId });
+    api.auth.provider().startSession(token, data, { ip, accountId });
     return { status: 'logged', token };
   },
 });

--- a/db/data.sql
+++ b/db/data.sql
@@ -1,18 +1,18 @@
 INSERT INTO "Identifier" DEFAULT VALUES;
 INSERT INTO "Account" ("id", "login", "password")
-VALUES (lastval(), 'admin', 'ypMEd9FwvtlOjcvH94iICQ==:V6LnSOVwXzENxeLCJk59Toadea7oaA1IxYulAOtKkL9tBxjEPOw085vYalEdLDoe8xbrXQlhh7QRGzrSe8Bthw==');
+VALUES (lastval(), 'admin', '$scrypt$N=32768,r=8,p=1,maxmem=67108864$Y33PUdCTNJuYb7FKkfbT/E4zWi2cukceqV7vBeL+ZmI$vPMMSHnn/izf7lnQtv9/Ilync+JmKEHwn4vB94X3qe+QS2D9jqjRvZ8+tzSk7A6rB3paznAjlKaXK2C/xYU9Pg');
 
 INSERT INTO "Identifier" DEFAULT VALUES;
 INSERT INTO "Account" ("id", "login", "password")
-VALUES (lastval(), 'marcus', 'dpHw0OUNBz76nuqrXZbeYQ==:wpvUVgi8Yp9rJ0yZyBWecaWP2EL/ahpxZY74KOVfhAYbAZSq6mWqjsQwtCvIPcSKZqUVpVb13JcSciB2fA+6Tg==');
+VALUES (lastval(), 'marcus', '$scrypt$N=32768,r=8,p=1,maxmem=67108864$CEUCHFbTTOvyD/VMi3wrFE1DYS9UNYQbTmL6fOx1BwY$MU1M+TH4/6lmq5b8k/kyCvaNXC68oB9oTTDvtRoaeu61+1EKHNGx2E8FfUWuB7Y3DBkfKqhN37Y7FnIuYgyTzQ');
 
 INSERT INTO "Identifier" DEFAULT VALUES;
 INSERT INTO "Account" ("id", "login", "password")
-VALUES (lastval(), 'user', 'r8zb8AdrlPSh5wNy6hqOxg==:HyO5rvOFLtwzU+OZ9qFi3ADXlVccDJWGSfUS8mVq43spJ6sxyliUdW3i53hOPdkFAtDn3EAQMttOlIoJap1lTQ==');
+VALUES (lastval(), 'user', '$scrypt$N=32768,r=8,p=1,maxmem=67108864$dSBT3AVxqctYVBDRDaIzc7e9Nxvtoqf3kQgdSrdo+5Y$Zv3CriftrUsPmGaqqptvVsw8D18J7G+VYLsasqJGSLQpqkuAi2Tm4sMgpXvwe3GfDv6KA9XLC5dH4VlGGddJiw  ');
 
 INSERT INTO "Identifier" DEFAULT VALUES;
 INSERT INTO "Account" ("id", "login", "password")
-VALUES (lastval(), 'iskandar', 'aqX1O4bKXiwC/Jh2EKNIYw==:bpE4TARNg09vb2Libn1c00YRxcvoklB9zVSbD733LwQQFUuAm7WHP85PbZXwEbbeOVPIFHgflR4cvEmvYkr76g==');
+VALUES (lastval(), 'iskandar', '$scrypt$N=32768,r=8,p=1,maxmem=67108864$SDeMXuBRl38SNKpf5+1abpIKrUhp/EfX9YsHQLwlrnA$KEY2UOaUJEEYtURagtobQFWxBIBvOzMpAqwWkiDXGI/NJwGowbzswoNLbzcGcsGTjs05eHc00jaSgNsaVazHew');
 
 -- Examples login/password
 -- admin/123456

--- a/setup.js
+++ b/setup.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const fsp = require('node:fs').promises;
 const path = require('node:path');
 const pg = require('pg');
@@ -9,7 +7,7 @@ const POSTGRES = {
   host: '127.0.0.1',
   port: 5432,
   database: 'postgres',
-  user: 'postgres',
+  user: 'abuglak',
   password: 'postgres',
 };
 

--- a/setup.js
+++ b/setup.js
@@ -7,7 +7,7 @@ const POSTGRES = {
   host: '127.0.0.1',
   port: 5432,
   database: 'postgres',
-  user: 'abuglak',
+  user: 'postgres',
   password: 'postgres',
 };
 

--- a/setup.js
+++ b/setup.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const fsp = require('node:fs').promises;
 const path = require('node:path');
 const pg = require('pg');

--- a/static/client.js
+++ b/static/client.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const transport = {};
 
 let callId = 1;
@@ -74,6 +72,6 @@ const scaffold = (url) => {
       method: ['arg'],
     },
   });
-  const data = await api.auth.signin('marcus', 'marcus');
+  const data = await api.auth.signin({ login: 'marcus', password: 'marcus' });
   console.dir({ data });
 })();


### PR DESCRIPTION
- fixed `client.js` calling method 'signin' (this method want to have an object)
- fixed `provied.js` (using `common.js` instead of `metautil` & using `db.crud` from 'db.js')
- fixed `signin` method
- generate new passwords for account in `data.sql` that are  suitable with hashing params in `common.js` (in `common.js` we use hashing like in metautil by default, so previous passwords simply could not be proccessed by `common.js` and `metautil`)